### PR TITLE
<WIP> corner case for nd4j dataset with vector

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -105,14 +105,6 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      * @param labelsMask Mask array for labels, may be null
      */
     public DataSet(INDArray features, INDArray labels, INDArray featuresMask, INDArray labelsMask) {
-        if (features.isVector()) {
-            long dim = features.size(0);
-            features = features.reshape(1,dim);
-        }
-        if (labels.isVector()) {
-            long dim = labels.size(0);
-            labels = labels.reshape(1,dim);
-        }
         this.features = features;
         this.labels = labels;
         this.featuresMask = featuresMask;
@@ -1146,10 +1138,16 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
 
     @Override
     public int numExamples() {
-        if (getFeatures() != null)
+        if (getFeatures() != null) {
+            if (getFeatures().isVector())
+                return 1;
             return (int) getFeatures().size(0);
-        else if (getLabels() != null)
+        }
+        else if (getLabels() != null) {
+            if (getLabels().isVector())
+                return 1;
             return (int) getLabels().size(0);
+        }
         return 0;
     }
 

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/dataset/DataSet.java
@@ -105,6 +105,14 @@ public class DataSet implements org.nd4j.linalg.dataset.api.DataSet {
      * @param labelsMask Mask array for labels, may be null
      */
     public DataSet(INDArray features, INDArray labels, INDArray featuresMask, INDArray labelsMask) {
+        if (features.isVector()) {
+            long dim = features.size(0);
+            features = features.reshape(1,dim);
+        }
+        if (labels.isVector()) {
+            long dim = labels.size(0);
+            labels = labels.reshape(1,dim);
+        }
         this.features = features;
         this.labels = labels;
         this.featuresMask = featuresMask;

--- a/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/DataSetTest.java
+++ b/nd4j/nd4j-backends/nd4j-tests/src/test/java/org/nd4j/linalg/dataset/DataSetTest.java
@@ -71,6 +71,18 @@ public class DataSetTest extends BaseNd4jTest {
     }
 
     @Test
+    public void testSingleInstance() {
+        Random random = new Random();
+        double [] randomData = new double[10];
+        for (int i=0;i<10;i++) {
+            randomData[i] = random.nextDouble();
+        }
+        DataSet ds = new DataSet(Nd4j.create(Arrays.copyOfRange(randomData,0,8)),Nd4j.create(Arrays.copyOfRange(randomData,8,10)));
+        System.out.println(ds);
+        assertEquals(1,ds.numExamples());
+    }
+
+    @Test
     public void  testViewIterator2(){
 
         INDArray f = Nd4j.linspace(1,100,100, DataType.DOUBLE).reshape('c', 10, 10);


### PR DESCRIPTION
Signed-off-by: eraly <susan.eraly@gmail.com>

## What changes were proposed in this pull request?
We don't check for ranks when creating a dataset. We allow users to create a dataset from vectors which works fine till you call numExamples. This is a simple fix with reshape in the constructor.

## How was this patch tested?
Unit test added

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
