### PR TITLE
Fix BERT word piece tokenizer stack overflow error

### DIFF
--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizer.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/main/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizer.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  */
 @Slf4j
 public class BertWordPieceTokenizer implements Tokenizer {
-    public static final Pattern splitPattern = Pattern.compile("(\\p{javaWhitespace}|((?<=\\p{Punct})|(?=\\p{Punct})))+");
+    public static final Pattern splitPattern = Pattern.compile("\\p{javaWhitespace}+|((?<=\\p{Punct})+|(?=\\p{Punct}+))");
 
     private final List<String> tokens;
     private final TokenPreProcess preTokenizePreProcessor;

--- a/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizerTests.java
+++ b/deeplearning4j/deeplearning4j-nlp-parent/deeplearning4j-nlp/src/test/java/org/deeplearning4j/text/tokenization/tokenizer/BertWordPieceTokenizerTests.java
@@ -220,4 +220,23 @@ public class BertWordPieceTokenizerTests extends BaseDL4JTest {
         String exp = s.toLowerCase();
         assertEquals(exp, s2);
     }
+
+    @Test
+    public void testTokenizerHandlesLargeContiguousWhitespace() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        sb.append("apple.");
+        for (int i = 0; i < 10000; i++) {
+            sb.append(" ");
+        }
+        sb.append(".pen. .pineapple");
+
+        File f = Resources.asFile("deeplearning4j-nlp/bert/uncased_L-12_H-768_A-12/vocab.txt");
+        BertWordPieceTokenizerFactory t = new BertWordPieceTokenizerFactory(f, true, true, StandardCharsets.UTF_8);
+
+        Tokenizer tokenizer = t.create(sb.toString());
+        List<String> list = tokenizer.getTokens();
+        System.out.println(list);
+
+        assertEquals(9, list.size());
+    }
 }


### PR DESCRIPTION
Encountered a document that caused a StackOverflowError with our current WordPieceTokenizer and isolated the problem to the regular expression we use to split the input string into tokens.

A barebones example (just the Pattern and the problem causing doc) can be found here: https://gist.github.com/wmeddie/eb88004f451a67e1b27c84ef83655c24

I've added a test that should also cause the StackOverflowError with the previous implementation.

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.