### PR TITLE
Making TypeName enum public

### DIFF
--- a/datavec/datavec-python/src/main/java/org/datavec/python/PythonType.java
+++ b/datavec/datavec-python/src/main/java/org/datavec/python/PythonType.java
@@ -36,7 +36,7 @@ public abstract class PythonType<T> {
     public abstract T toJava(PythonObject pythonObject) throws PythonException;
     private final TypeName typeName;
 
-    enum TypeName{
+    public enum TypeName{
         STR,
         INT,
         FLOAT,


### PR DESCRIPTION
## What changes were proposed in this pull request?
TypeName enum was not accessible for external classes.  

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

## Quick checklist

The following checklist helps ensure your PR is complete:

- [ ] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [ ] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [ ] Created tests for any significant new code additions.
- [ ] Relevant tests for your changes are passing.
