### PR TITLE
RL4J - Added a trainer & few agent-learner builders

### DIFF
--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/AgentLearner.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/AgentLearner.java
@@ -15,8 +15,10 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.agent;
 
+import lombok.Data;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.agent.learning.behavior.ILearningBehavior;
 import org.deeplearning4j.rl4j.environment.Environment;
 import org.deeplearning4j.rl4j.environment.StepResult;
@@ -41,12 +43,17 @@ public class AgentLearner<ACTION> extends Agent<ACTION> implements IAgentLearner
      * @param environment The {@link Environment} to be used
      * @param transformProcess The {@link TransformProcess} to be used to transform the raw observations into usable ones.
      * @param policy The {@link IPolicy} to be used
-     * @param maxEpisodeSteps The maximum number of steps an episode can have before being interrupted. Use null to have no max.
+     * @param configuration The configuration for the AgentLearner
      * @param id A user-supplied id to identify the instance.
      * @param learningBehavior The {@link ILearningBehavior} that will be used to supervise the learning.
      */
-    public AgentLearner(Environment<ACTION> environment, TransformProcess transformProcess, IPolicy<ACTION> policy, Integer maxEpisodeSteps, String id, @NonNull ILearningBehavior<ACTION> learningBehavior) {
-        super(environment, transformProcess, policy, maxEpisodeSteps, id);
+    public AgentLearner(Environment<ACTION> environment,
+                        TransformProcess transformProcess,
+                        IPolicy<ACTION> policy,
+                        Configuration configuration,
+                        String id,
+                        @NonNull ILearningBehavior<ACTION> learningBehavior) {
+        super(environment, transformProcess, policy, configuration, id);
 
         this.learningBehavior = learningBehavior;
     }
@@ -86,30 +93,8 @@ public class AgentLearner<ACTION> extends Agent<ACTION> implements IAgentLearner
         ++totalStepCount;
     }
 
-    // FIXME: parent is still visible
-    public static <ACTION> AgentLearner.Builder<ACTION, AgentLearner<ACTION>> builder(Environment<ACTION> environment,
-                                                   TransformProcess transformProcess,
-                                                   IPolicy<ACTION> policy,
-                                                   ILearningBehavior<ACTION> learningBehavior) {
-        return new AgentLearner.Builder<ACTION, AgentLearner<ACTION>>(environment, transformProcess, policy, learningBehavior);
-    }
-
-    public static class Builder<ACTION, AGENT_TYPE extends AgentLearner<ACTION>> extends Agent.Builder<ACTION, AGENT_TYPE> {
-
-        private final ILearningBehavior<ACTION> learningBehavior;
-
-        public Builder(@NonNull Environment<ACTION> environment,
-                       @NonNull TransformProcess transformProcess,
-                       @NonNull IPolicy<ACTION> policy,
-                       @NonNull ILearningBehavior<ACTION> learningBehavior) {
-            super(environment, transformProcess, policy);
-
-            this.learningBehavior = learningBehavior;
-        }
-
-        @Override
-        public AGENT_TYPE build() {
-            return (AGENT_TYPE)new AgentLearner<ACTION>(environment, transformProcess, policy, maxEpisodeSteps, id, learningBehavior);
-        }
+    @SuperBuilder
+    @Data
+    public static class Configuration extends Agent.Configuration {
     }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/NStepQLearning.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/NStepQLearning.java
@@ -15,6 +15,10 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.agent.learning.algorithm;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
 import org.deeplearning4j.rl4j.agent.learning.update.Gradients;
 import org.deeplearning4j.rl4j.experience.StateActionPair;
@@ -39,19 +43,18 @@ public class NStepQLearning implements IUpdateAlgorithm<Gradients, StateActionPa
     private final double gamma;
 
     /**
-     * @param current The \u03b8' parameters (the thread-specific network)
-     * @param target The \u03b8<sup>-</sup> parameters (the global target network)
+     * @param current The &theta;' parameters (the thread-specific network)
+     * @param target The &theta;<sup>&ndash;</sup> parameters (the global target network)
      * @param actionSpaceSize The numbers of possible actions that can be taken on the environment
-     * @param gamma The discount factor
      */
-    public NStepQLearning(ITrainableNeuralNet current,
-                          IOutputNeuralNet target,
+    public NStepQLearning(@NonNull ITrainableNeuralNet current,
+                          @NonNull IOutputNeuralNet target,
                           int actionSpaceSize,
-                          double gamma) {
+                          @NonNull Configuration configuration) {
         this.current = current;
         this.target = target;
         this.actionSpaceSize = actionSpaceSize;
-        this.gamma = gamma;
+        this.gamma = configuration.getGamma();
     }
 
     @Override
@@ -87,5 +90,15 @@ public class NStepQLearning implements IUpdateAlgorithm<Gradients, StateActionPa
         FeaturesLabels featuresLabels = new FeaturesLabels(features);
         featuresLabels.putLabels(CommonLabelNames.QValues, labels);
         return current.computeGradients(featuresLabels);
+    }
+
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        /**
+         * The discount factor (default is 0.99)
+         */
+        @Builder.Default
+        double gamma = 0.99;
     }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/BaseDQNAlgorithm.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/BaseDQNAlgorithm.java
@@ -16,6 +16,7 @@
 
 package org.deeplearning4j.rl4j.agent.learning.algorithm.dqn;
 
+import lombok.NonNull;
 import org.deeplearning4j.rl4j.network.IOutputNeuralNet;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
@@ -30,22 +31,19 @@ public abstract class BaseDQNAlgorithm extends BaseTransitionTDAlgorithm {
     private final IOutputNeuralNet targetQNetwork;
 
     /**
-     * In litterature, this corresponds to Q{net}(s(t+1), a)
+     * In literature, this corresponds to Q<sub>net</sub>(s(t+1), a)
      */
     protected INDArray qNetworkNextObservation;
 
     /**
-     * In litterature, this corresponds to Q{tnet}(s(t+1), a)
+     * In literature, this corresponds to Q<sub>tnet</sub>(s(t+1), a)
      */
     protected INDArray targetQNetworkNextObservation;
 
-    protected BaseDQNAlgorithm(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, double gamma) {
-        super(qNetwork, gamma);
-        this.targetQNetwork = targetQNetwork;
-    }
-
-    protected BaseDQNAlgorithm(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, double gamma, double errorClamp) {
-        super(qNetwork, gamma, errorClamp);
+    protected BaseDQNAlgorithm(IOutputNeuralNet qNetwork,
+                               @NonNull IOutputNeuralNet targetQNetwork,
+                               BaseTransitionTDAlgorithm.Configuration configuration) {
+        super(qNetwork, configuration);
         this.targetQNetwork = targetQNetwork;
     }
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/BaseTransitionTDAlgorithm.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/BaseTransitionTDAlgorithm.java
@@ -16,6 +16,10 @@
 
 package org.deeplearning4j.rl4j.agent.learning.algorithm.dqn;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
 import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
 import org.deeplearning4j.rl4j.learning.sync.Transition;
@@ -39,25 +43,14 @@ public abstract class BaseTransitionTDAlgorithm implements IUpdateAlgorithm<Feat
     /**
      *
      * @param qNetwork The Q-Network
-     * @param gamma The discount factor
-     * @param errorClamp Will prevent the new Q-Value from being farther than <i>errorClamp</i> away from the previous value. Double.NaN will disable the clamping.
+     * @param configuration The {@link Configuration} to use
      */
-    protected BaseTransitionTDAlgorithm(IOutputNeuralNet qNetwork, double gamma, double errorClamp) {
+    protected BaseTransitionTDAlgorithm(@NonNull IOutputNeuralNet qNetwork, @NonNull Configuration configuration) {
         this.qNetwork = qNetwork;
-        this.gamma = gamma;
+        this.gamma = configuration.getGamma();
 
-        this.errorClamp = errorClamp;
+        this.errorClamp = configuration.getErrorClamp();
         isClamped = !Double.isNaN(errorClamp);
-    }
-
-    /**
-     *
-     * @param qNetwork The Q-Network
-     * @param gamma The discount factor
-     * Note: Error clamping is disabled with this ctor
-     */
-    protected BaseTransitionTDAlgorithm(IOutputNeuralNet qNetwork, double gamma) {
-        this(qNetwork, gamma, Double.NaN);
     }
 
     /**
@@ -107,5 +100,21 @@ public abstract class BaseTransitionTDAlgorithm implements IUpdateAlgorithm<Feat
         featuresLabels.putLabels(CommonLabelNames.QValues, updatedQValues);
 
         return featuresLabels;
+    }
+
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        /**
+         * The discount factor (default is 0.99)
+         */
+        @Builder.Default
+        double gamma = 0.99;
+
+        /**
+         * Will prevent the new Q-Value from being farther than <i>errorClamp</i> away from the previous value. Double.NaN will disable the clamping (default).
+         */
+        @Builder.Default
+        double errorClamp = Double.NaN;
     }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/DoubleDQN.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/DoubleDQN.java
@@ -29,15 +29,13 @@ public class DoubleDQN extends BaseDQNAlgorithm {
 
     private static final int ACTION_DIMENSION_IDX = 1;
 
-    // In litterature, this corresponds to: max_{a}Q(s_{t+1}, a)
+    // In literature, this corresponds to: max<sub>a</sub> Q(s<sub>t+1</sub>, a)
     private INDArray maxActionsFromQNetworkNextObservation;
 
-    public DoubleDQN(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, double gamma) {
-        super(qNetwork, targetQNetwork, gamma);
-    }
-
-    public DoubleDQN(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, double gamma, double errorClamp) {
-        super(qNetwork, targetQNetwork, gamma, errorClamp);
+    public DoubleDQN(IOutputNeuralNet qNetwork,
+                     IOutputNeuralNet targetQNetwork,
+                     BaseTransitionTDAlgorithm.Configuration configuration) {
+        super(qNetwork, targetQNetwork, configuration);
     }
 
     @Override
@@ -48,8 +46,8 @@ public class DoubleDQN extends BaseDQNAlgorithm {
     }
 
     /**
-     * In litterature, this corresponds to:<br />
-     *      Q(s_t, a_t) = R_{t+1} + \gamma * Q_{tar}(s_{t+1}, max_{a}Q(s_{t+1}, a))
+     * In literature, this corresponds to:<br />
+     *      Q(s<sub>t</sub>, a<sub>t</sub>) = R<sub>t+1</sub> + &gamma; * Q<sub>tar</sub>(s<sub>t+1</sub>, max<sub>a</sub> Q(s<sub>t+1</sub>, a))
      * @param batchIdx The index in the batch of the current transition
      * @param reward The reward of the current transition
      * @param isTerminal True if it's the last transition of the "game"

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/StandardDQN.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/StandardDQN.java
@@ -29,16 +29,15 @@ public class StandardDQN extends BaseDQNAlgorithm {
 
     private static final int ACTION_DIMENSION_IDX = 1;
 
-    // In litterature, this corresponds to: max_{a}Q_{tar}(s_{t+1}, a)
+    /**
+     * In literature, this corresponds to: max<sub>a</sub> Q<sub>tar</sub>(s<sub>t+1</sub>, a)
+     */
     private INDArray maxActionsFromQTargetNextObservation;
 
-    public StandardDQN(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, double gamma) {
-        super(qNetwork, targetQNetwork, gamma);
+    public StandardDQN(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, Configuration configuration) {
+        super(qNetwork, targetQNetwork, configuration);
     }
 
-    public StandardDQN(IOutputNeuralNet qNetwork, IOutputNeuralNet targetQNetwork, double gamma, double errorClamp) {
-        super(qNetwork, targetQNetwork, gamma, errorClamp);
-    }
 
     @Override
     protected void initComputation(INDArray observations, INDArray nextObservations) {
@@ -48,8 +47,8 @@ public class StandardDQN extends BaseDQNAlgorithm {
     }
 
     /**
-     * In litterature, this corresponds to:<br />
-     *      Q(s_t, a_t) = R_{t+1} + \gamma * max_{a}Q_{tar}(s_{t+1}, a)
+     * In literature, this corresponds to:<br />
+     *      Q(s<sub>t</sub>, a<sub>t</sub>) = R<sub>t+1</sub> + &gamma; * max<sub>a</sub> Q<sub>tar</sub>(s<sub>t+1</sub>, a)
      * @param batchIdx The index in the batch of the current transition
      * @param reward The reward of the current transition
      * @param isTerminal True if it's the last transition of the "game"

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/behavior/LearningBehavior.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/behavior/LearningBehavior.java
@@ -16,6 +16,7 @@
 package org.deeplearning4j.rl4j.agent.learning.behavior;
 
 import lombok.Builder;
+import lombok.NonNull;
 import org.deeplearning4j.rl4j.agent.learning.update.IUpdateRule;
 import org.deeplearning4j.rl4j.experience.ExperienceHandler;
 import org.deeplearning4j.rl4j.observation.Observation;
@@ -30,7 +31,10 @@ import org.deeplearning4j.rl4j.observation.Observation;
 @Builder
 public class LearningBehavior<ACTION, EXPERIENCE_TYPE> implements ILearningBehavior<ACTION> {
 
+    @NonNull
     private final ExperienceHandler<ACTION, EXPERIENCE_TYPE> experienceHandler;
+
+    @NonNull
     private final IUpdateRule<EXPERIENCE_TYPE> updateRule;
 
     @Override

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/update/UpdateRule.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/update/UpdateRule.java
@@ -16,6 +16,7 @@
 package org.deeplearning4j.rl4j.agent.learning.update;
 
 import lombok.Getter;
+import lombok.NonNull;
 import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
 import org.deeplearning4j.rl4j.agent.learning.update.updater.INeuralNetUpdater;
 
@@ -37,8 +38,8 @@ public class UpdateRule<RESULT_TYPE, EXPERIENCE_TYPE> implements IUpdateRule<EXP
     @Getter
     private int updateCount = 0;
 
-    public UpdateRule(IUpdateAlgorithm<RESULT_TYPE, EXPERIENCE_TYPE> updateAlgorithm,
-                      INeuralNetUpdater<RESULT_TYPE> updater) {
+    public UpdateRule(@NonNull IUpdateAlgorithm<RESULT_TYPE, EXPERIENCE_TYPE> updateAlgorithm,
+                      @NonNull INeuralNetUpdater<RESULT_TYPE> updater) {
         this.updateAlgorithm = updateAlgorithm;
         this.updater = updater;
     }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/update/updater/GradientsNeuralNetUpdater.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/update/updater/GradientsNeuralNetUpdater.java
@@ -15,6 +15,10 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.agent.learning.update.updater;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.agent.learning.update.Gradients;
 import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
 
@@ -33,17 +37,16 @@ public class GradientsNeuralNetUpdater implements INeuralNetUpdater<Gradients> {
     /**
      * @param current The current {@link ITrainableNeuralNet network}
      * @param target The target {@link ITrainableNeuralNet network}
-     * @param targetUpdateFrequency Will synchronize the target network at every <i>targetUpdateFrequency</i> updates
      *
      * Note: Presently async is not supported
      */
-    public GradientsNeuralNetUpdater(ITrainableNeuralNet current,
-                                     ITrainableNeuralNet target,
-                                     int targetUpdateFrequency) {
+    public GradientsNeuralNetUpdater(@NonNull ITrainableNeuralNet current,
+                                     @NonNull ITrainableNeuralNet target,
+                                     @NonNull Configuration configuration) {
         this.current = current;
         this.target = target;
 
-        this.targetUpdateFrequency = targetUpdateFrequency;
+        this.targetUpdateFrequency = configuration.getTargetUpdateFrequency();
     }
 
     /**
@@ -62,4 +65,13 @@ public class GradientsNeuralNetUpdater implements INeuralNetUpdater<Gradients> {
         }
     }
 
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        /**
+         * Will synchronize the target network at every <i>targetUpdateFrequency</i> updates (default: no update)
+         */
+        @Builder.Default
+        int targetUpdateFrequency = Integer.MAX_VALUE;
+    }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/update/updater/LabelsNeuralNetUpdater.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/learning/update/updater/LabelsNeuralNetUpdater.java
@@ -15,8 +15,13 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.agent.learning.update.updater;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
 import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.nd4j.common.base.Preconditions;
 
 /**
  * A {@link INeuralNetUpdater} that updates a neural network and sync a target network at defined intervals
@@ -33,17 +38,18 @@ public class LabelsNeuralNetUpdater implements INeuralNetUpdater<FeaturesLabels>
     /**
      * @param current The current {@link ITrainableNeuralNet network}
      * @param target The target {@link ITrainableNeuralNet network}
-     * @param targetUpdateFrequency Will synchronize the target network at every <i>targetUpdateFrequency</i> updates
+     * @param configuration The {@link Configuration} to use
      *
      * Note: Presently async is not supported
      */
-    public LabelsNeuralNetUpdater(ITrainableNeuralNet current,
-                                  ITrainableNeuralNet target,
-                                  int targetUpdateFrequency) {
+    public LabelsNeuralNetUpdater(@NonNull ITrainableNeuralNet current,
+                                  @NonNull ITrainableNeuralNet target,
+                                  @NonNull Configuration configuration) {
+        Preconditions.checkArgument(configuration.getTargetUpdateFrequency() > 0, "Configuration: targetUpdateFrequency must be greater than 0, got: ", configuration.getTargetUpdateFrequency());
         this.current = current;
         this.target = target;
 
-        this.targetUpdateFrequency = targetUpdateFrequency;
+        this.targetUpdateFrequency = configuration.getTargetUpdateFrequency();
     }
 
     /**
@@ -60,6 +66,16 @@ public class LabelsNeuralNetUpdater implements INeuralNetUpdater<FeaturesLabels>
         if(++updateCount % targetUpdateFrequency == 0) {
             target.copy(current);
         }
+    }
+
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        /**
+         * Will synchronize the target network at every <i>targetUpdateFrequency</i> updates (default: no update)
+         */
+        @Builder.Default
+        int targetUpdateFrequency = Integer.MAX_VALUE;
     }
 
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListener.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListener.java
@@ -63,4 +63,12 @@ public interface AgentListener<ACTION> {
      * @return A {@link ListenerResponse}.
      */
     AgentListener.ListenerResponse onAfterStep(Agent agent, StepResult stepResult);
+
+    /**
+     * Called after the episode has ended.
+     *
+     * @param agent The agent that generated the event
+     *
+     */
+    void onAfterEpisode(Agent agent);
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListenerList.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/agent/listener/AgentListenerList.java
@@ -86,4 +86,16 @@ public class AgentListenerList<ACTION> {
 
         return true;
     }
+
+    /**
+     * This method will notify all listeners that an episode has finished.
+     *
+     * @param agent The agent that generated the event.
+     */
+    public void notifyAfterEpisode(Agent<ACTION> agent) {
+        for (AgentListener<ACTION> listener : listeners) {
+            listener.onAfterEpisode(agent);
+        }
+    }
+
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/BaseAgentLearnerBuilder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/BaseAgentLearnerBuilder.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.builder;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.AgentLearner;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
+import org.deeplearning4j.rl4j.agent.learning.behavior.ILearningBehavior;
+import org.deeplearning4j.rl4j.agent.learning.behavior.LearningBehavior;
+import org.deeplearning4j.rl4j.agent.learning.update.IUpdateRule;
+import org.deeplearning4j.rl4j.agent.learning.update.UpdateRule;
+import org.deeplearning4j.rl4j.agent.learning.update.updater.INeuralNetUpdater;
+import org.deeplearning4j.rl4j.agent.listener.AgentListener;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.experience.ExperienceHandler;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.deeplearning4j.rl4j.policy.IPolicy;
+
+import java.util.List;
+
+/**
+ * A base {@link IAgentLearner} builder that should be helpful in several common scenarios. <p/>
+ * <b>Note</b>: Classes implementing BaseAgentLearnerBuilder should be careful not to re-use a stateful and/or non thread-safe dependency
+ * through several calls to build(). In doubt, use a new instance.
+ * @param <ACTION> The type of action
+ * @param <EXPERIENCE_TYPE> The type of experiences
+ * @param <ALGORITHM_RESULT_TYPE> The response type of {@link org.deeplearning4j.rl4j.network.IOutputNeuralNet IOutputNeuralNet}.output()
+ */
+public abstract class BaseAgentLearnerBuilder<ACTION, EXPERIENCE_TYPE, ALGORITHM_RESULT_TYPE> implements Builder<IAgentLearner<ACTION>> {
+
+    private final Configuration<ACTION> configuration;
+    private final Builder<Environment<ACTION>> environmentBuilder;
+    private final Builder<TransformProcess> transformProcessBuilder;
+    protected final INetworksHandler networks;
+
+    protected int createdAgentLearnerCount;
+
+    public BaseAgentLearnerBuilder(@NonNull Configuration configuration,
+                                   @NonNull ITrainableNeuralNet neuralNet,
+                                   @NonNull Builder<Environment<ACTION>> environmentBuilder,
+                                   @NonNull Builder<TransformProcess> transformProcessBuilder) {
+        this.configuration = configuration;
+        this.environmentBuilder = environmentBuilder;
+        this.transformProcessBuilder = transformProcessBuilder;
+
+        // TODO: Support async setups
+        if(configuration.isAsynchronous()) {
+            throw new NotImplementedException("Asynchronous BaseAgentLearnerBuilder is not yet implemented");
+        }
+        this.networks = new SyncNetworkHandler(neuralNet);
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    private Environment<ACTION> environment;
+
+    @Getter(AccessLevel.PROTECTED)
+    private TransformProcess transformProcess;
+
+    @Getter(AccessLevel.PROTECTED)
+    private IPolicy<ACTION> policy;
+
+    @Getter(AccessLevel.PROTECTED)
+    private ExperienceHandler<ACTION, EXPERIENCE_TYPE> experienceHandler;
+
+    @Getter(AccessLevel.PROTECTED)
+    private IUpdateAlgorithm<ALGORITHM_RESULT_TYPE, EXPERIENCE_TYPE> updateAlgorithm;
+
+    @Getter(AccessLevel.PROTECTED)
+    private INeuralNetUpdater<ALGORITHM_RESULT_TYPE> neuralNetUpdater;
+
+    @Getter(AccessLevel.PROTECTED)
+    private IUpdateRule<EXPERIENCE_TYPE> updateRule;
+
+    @Getter(AccessLevel.PROTECTED)
+    private ILearningBehavior<ACTION> learningBehavior;
+
+    protected abstract IPolicy<ACTION> buildPolicy();
+    protected abstract ExperienceHandler<ACTION, EXPERIENCE_TYPE> buildExperienceHandler();
+    protected abstract IUpdateAlgorithm<ALGORITHM_RESULT_TYPE, EXPERIENCE_TYPE> buildUpdateAlgorithm();
+    protected abstract INeuralNetUpdater<ALGORITHM_RESULT_TYPE> buildNeuralNetUpdater();
+    protected IUpdateRule<EXPERIENCE_TYPE> buildUpdateRule() {
+        return new UpdateRule<ALGORITHM_RESULT_TYPE, EXPERIENCE_TYPE>(getUpdateAlgorithm(), getNeuralNetUpdater());
+    }
+    protected ILearningBehavior<ACTION> buildLearningBehavior() {
+        return LearningBehavior.<ACTION, EXPERIENCE_TYPE>builder()
+                .experienceHandler(getExperienceHandler())
+                .updateRule(getUpdateRule())
+                .build();
+    }
+
+    protected void resetForNewBuild() {
+        environment = environmentBuilder.build();
+        transformProcess = transformProcessBuilder.build();
+        policy = buildPolicy();
+        experienceHandler = buildExperienceHandler();
+        updateAlgorithm = buildUpdateAlgorithm();
+        neuralNetUpdater = buildNeuralNetUpdater();
+        updateRule = buildUpdateRule();
+        learningBehavior = buildLearningBehavior();
+
+        ++createdAgentLearnerCount;
+    }
+
+    protected String getThreadId() {
+        return "AgentLearner-" + createdAgentLearnerCount;
+    }
+
+    protected IAgentLearner<ACTION> buildAgentLearner() {
+        AgentLearner<ACTION> result = new AgentLearner(getEnvironment(), getTransformProcess(), getPolicy(), configuration.getAgentLearnerConfiguration(), getThreadId(), getLearningBehavior());
+        if(configuration.getAgentLearnerListeners() != null) {
+            for (AgentListener<ACTION> listener : configuration.getAgentLearnerListeners()) {
+                result.addListener(listener);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Build a properly assembled / configured IAgentLearner.
+     * @return a {@link IAgentLearner}
+     */
+    @Override
+    public IAgentLearner<ACTION> build() {
+        resetForNewBuild();
+        return buildAgentLearner();
+    }
+
+    @SuperBuilder
+    @Data
+    public static class Configuration<ACTION> {
+        /**
+         * The configuration that will be used to build the {@link AgentLearner}
+         */
+        AgentLearner.Configuration agentLearnerConfiguration;
+
+        /**
+         * A list of {@link AgentListener AgentListeners} that will be added to the AgentLearner. (default = null; no listeners)
+         */
+        List<AgentListener<ACTION>> agentLearnerListeners;
+
+        /**
+         * Tell the builder that the AgentLearners will be used in an asynchronous setup
+         */
+        boolean asynchronous;
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/BaseDQNAgentLearnerBuilder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/BaseDQNAgentLearnerBuilder.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.builder;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.BaseTransitionTDAlgorithm;
+import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
+import org.deeplearning4j.rl4j.agent.learning.update.updater.INeuralNetUpdater;
+import org.deeplearning4j.rl4j.agent.learning.update.updater.LabelsNeuralNetUpdater;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.environment.IActionSchema;
+import org.deeplearning4j.rl4j.experience.ExperienceHandler;
+import org.deeplearning4j.rl4j.experience.ReplayMemoryExperienceHandler;
+import org.deeplearning4j.rl4j.learning.sync.Transition;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.deeplearning4j.rl4j.policy.DQNPolicy;
+import org.deeplearning4j.rl4j.policy.EpsGreedy;
+import org.deeplearning4j.rl4j.policy.INeuralNetPolicy;
+import org.deeplearning4j.rl4j.policy.IPolicy;
+import org.nd4j.linalg.api.rng.Random;
+
+/**
+ * A base {@link IAgentLearner} builder that will setup these:
+ * <li>a epsilon-greedy policy</li>
+ * <li>a replay-memory experience handler</li>
+ * <li>a neural net updater that expects feature-labels update data</li>
+ *
+ * Used as the base of DQN builders.
+ */
+public abstract class BaseDQNAgentLearnerBuilder extends BaseAgentLearnerBuilder<Integer, Transition<Integer>, FeaturesLabels> {
+
+    @Getter(AccessLevel.PROTECTED)
+    private final Configuration configuration;
+
+    private final Random rnd;
+
+    public BaseDQNAgentLearnerBuilder(Configuration configuration,
+                                      ITrainableNeuralNet neuralNet,
+                                      Builder<Environment<Integer>> environmentBuilder,
+                                      Builder<TransformProcess> transformProcessBuilder,
+                                      Random rnd) {
+        super(configuration, neuralNet, environmentBuilder, transformProcessBuilder);
+        this.configuration = configuration;
+        this.rnd = rnd;
+    }
+
+    @Override
+    protected IPolicy<Integer> buildPolicy() {
+        INeuralNetPolicy<Integer> greedyPolicy = new DQNPolicy<Integer>(networks.getThreadCurrentNetwork());
+        IActionSchema<Integer> actionSchema = getEnvironment().getSchema().getActionSchema();
+        return new EpsGreedy(greedyPolicy, actionSchema, configuration.getPolicyConfiguration(), rnd);
+    }
+
+    @Override
+    protected ExperienceHandler<Integer, Transition<Integer>> buildExperienceHandler() {
+        return new ReplayMemoryExperienceHandler(configuration.getExperienceHandlerConfiguration(), rnd);
+    }
+
+    @Override
+    protected INeuralNetUpdater<FeaturesLabels> buildNeuralNetUpdater() {
+        return new LabelsNeuralNetUpdater(networks.getThreadCurrentNetwork(), networks.getTargetNetwork(), configuration.getNeuralNetUpdaterConfiguration());
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @SuperBuilder
+    @Data
+    public static class Configuration extends BaseAgentLearnerBuilder.Configuration<Integer> {
+        EpsGreedy.Configuration policyConfiguration;
+        ReplayMemoryExperienceHandler.Configuration experienceHandlerConfiguration;
+        LabelsNeuralNetUpdater.Configuration neuralNetUpdaterConfiguration;
+        BaseTransitionTDAlgorithm.Configuration updateAlgorithmConfiguration;
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/DoubleDQNBuilder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/DoubleDQNBuilder.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.builder;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN;
+import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.learning.sync.Transition;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.nd4j.linalg.api.rng.Random;
+
+/**
+ * A {@link IAgentLearner} builder that will setup a {@link DoubleDQN double-DQN} algorithm in addition to the setup done by {@link BaseDQNAgentLearnerBuilder}.
+ */
+public class DoubleDQNBuilder extends BaseDQNAgentLearnerBuilder {
+
+
+    public DoubleDQNBuilder(Configuration configuration,
+                            ITrainableNeuralNet neuralNet,
+                            Builder<Environment<Integer>> environmentBuilder,
+                            Builder<TransformProcess> transformProcessBuilder,
+                            Random rnd) {
+        super(configuration, neuralNet, environmentBuilder, transformProcessBuilder, rnd);
+    }
+
+    @Override
+    protected IUpdateAlgorithm<FeaturesLabels, Transition<Integer>> buildUpdateAlgorithm() {
+        return new DoubleDQN(networks.getThreadCurrentNetwork(), networks.getTargetNetwork(), getConfiguration().getUpdateAlgorithmConfiguration());
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @SuperBuilder
+    @Data
+    public static class Configuration extends BaseDQNAgentLearnerBuilder.Configuration {
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/INetworksHandler.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/INetworksHandler.java
@@ -13,31 +13,31 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
-package org.deeplearning4j.rl4j.network;
+package org.deeplearning4j.rl4j.builder;
 
-import org.deeplearning4j.rl4j.observation.Observation;
-import org.nd4j.linalg.api.ndarray.INDArray;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
 
 /**
- * An interface defining the output aspect of a {@link NeuralNet}.
+ * An interface that abstract what the different networks are depending on the setup (sync vs async)
  */
-public interface IOutputNeuralNet {
+public interface INetworksHandler {
     /**
-     * Compute the output for the supplied observation.
-     * @param observation An {@link Observation}
-     * @return The ouptut of the network
+     * @return The global shared target parameters &theta;<sup>&ndash;</sup>
      */
-    INDArray output(Observation observation);
+    ITrainableNeuralNet getTargetNetwork();
 
     /**
-     * Compute the output for the supplied batch.
-     * @param batch
-     * @return The ouptut of the network
+     * @return The thread-specific parameters &theta;'
      */
-    INDArray output(INDArray batch);
+    ITrainableNeuralNet getThreadCurrentNetwork();
 
     /**
-     * Clear the neural net of any previous state
+     * @return The global shared parameters &theta;
      */
-    void reset();
+    ITrainableNeuralNet getGlobalCurrentNetwork();
+
+    /**
+     * Perform the required changes before a new IAgentLearner is built
+     */
+    void resetForNewBuild();
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/NStepQLearningBuilder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/NStepQLearningBuilder.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.builder;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.NStepQLearning;
+import org.deeplearning4j.rl4j.agent.learning.update.Gradients;
+import org.deeplearning4j.rl4j.agent.learning.update.updater.GradientsNeuralNetUpdater;
+import org.deeplearning4j.rl4j.agent.learning.update.updater.INeuralNetUpdater;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.environment.IActionSchema;
+import org.deeplearning4j.rl4j.experience.ExperienceHandler;
+import org.deeplearning4j.rl4j.experience.StateActionExperienceHandler;
+import org.deeplearning4j.rl4j.experience.StateActionPair;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.deeplearning4j.rl4j.policy.DQNPolicy;
+import org.deeplearning4j.rl4j.policy.EpsGreedy;
+import org.deeplearning4j.rl4j.policy.INeuralNetPolicy;
+import org.deeplearning4j.rl4j.policy.IPolicy;
+import org.nd4j.linalg.api.rng.Random;
+
+/**
+ * A {@link IAgentLearner} builder that will setup a {@link NStepQLearning n-step Q-Learning} algorithm with these:
+ * <li>a epsilon-greedy policy</li>
+ * <li>a n-step state-action-reward experience handler</li>
+ * <li>a neural net updater that expects gradient update data</li>
+ * <li>a n-step Q-Learning gradient conputation algorithm</li>
+ */
+public class NStepQLearningBuilder extends BaseAgentLearnerBuilder<Integer, StateActionPair<Integer>, Gradients>{
+
+
+    private final Configuration configuration;
+    private final Random rnd;
+
+    public NStepQLearningBuilder(Configuration configuration,
+                                 ITrainableNeuralNet neuralNet,
+                                 Builder<Environment<Integer>> environmentBuilder,
+                                 Builder<TransformProcess> transformProcessBuilder,
+                                 Random rnd) {
+        super(configuration, neuralNet, environmentBuilder, transformProcessBuilder);
+        this.configuration = configuration;
+        this.rnd = rnd;
+    }
+
+    @Override
+    protected IPolicy<Integer> buildPolicy() {
+        INeuralNetPolicy<Integer> greedyPolicy = new DQNPolicy<Integer>(networks.getThreadCurrentNetwork());
+        IActionSchema<Integer> actionSchema = getEnvironment().getSchema().getActionSchema();
+        return new EpsGreedy(greedyPolicy, actionSchema, configuration.getPolicyConfiguration(), rnd);
+    }
+
+    @Override
+    protected ExperienceHandler<Integer, StateActionPair<Integer>> buildExperienceHandler() {
+        return new StateActionExperienceHandler<Integer>(configuration.getExperienceHandlerConfiguration());
+    }
+
+    @Override
+    protected IUpdateAlgorithm<Gradients, StateActionPair<Integer>> buildUpdateAlgorithm() {
+        IActionSchema<Integer> actionSchema = getEnvironment().getSchema().getActionSchema();
+        return new NStepQLearning(networks.getThreadCurrentNetwork(), networks.getTargetNetwork(), actionSchema.getActionSpaceSize(), configuration.getNstepQLearningConfiguration());
+    }
+
+    @Override
+    protected INeuralNetUpdater<Gradients> buildNeuralNetUpdater() {
+        return new GradientsNeuralNetUpdater(networks.getThreadCurrentNetwork(), networks.getTargetNetwork(), configuration.getNeuralNetUpdaterConfiguration());
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @SuperBuilder
+    @Data
+    public static class Configuration extends BaseAgentLearnerBuilder.Configuration<Integer> {
+        EpsGreedy.Configuration policyConfiguration;
+        GradientsNeuralNetUpdater.Configuration neuralNetUpdaterConfiguration;
+        NStepQLearning.Configuration nstepQLearningConfiguration;
+        StateActionExperienceHandler.Configuration experienceHandlerConfiguration;
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/StandardDQNBuilder.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/StandardDQNBuilder.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.builder;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN;
+import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.learning.sync.Transition;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.nd4j.linalg.api.rng.Random;
+
+/**
+ * A {@link IAgentLearner} builder that will setup a {@link StandardDQN standard DQN} algorithm in addition to the setup done by {@link BaseDQNAgentLearnerBuilder}.
+ */
+public class StandardDQNBuilder extends BaseDQNAgentLearnerBuilder {
+
+
+    public StandardDQNBuilder(Configuration configuration,
+                              ITrainableNeuralNet neuralNet,
+                              Builder<Environment<Integer>> environmentBuilder,
+                              Builder<TransformProcess> transformProcessBuilder,
+                              Random rnd) {
+        super(configuration, neuralNet, environmentBuilder, transformProcessBuilder, rnd);
+    }
+
+    @Override
+    protected IUpdateAlgorithm<FeaturesLabels, Transition<Integer>> buildUpdateAlgorithm() {
+        return new StandardDQN(networks.getThreadCurrentNetwork(), networks.getTargetNetwork(), getConfiguration().getUpdateAlgorithmConfiguration());
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @SuperBuilder
+    @Data
+    public static class Configuration extends BaseDQNAgentLearnerBuilder.Configuration {
+    }
+}
+

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/SyncNetworkHandler.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/builder/SyncNetworkHandler.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.builder;
+
+import lombok.Getter;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+
+/**
+ * A {@link INetworksHandler} implementation for synchronous setups.<p/>
+ * The target network is cloned from the input network
+ * The thread-current and the global-current uses the input network directly.
+ * Note that there is no difference between the thread-current and the global-current in a sync setup.
+ */
+public class SyncNetworkHandler implements INetworksHandler {
+
+    @Getter
+    final ITrainableNeuralNet targetNetwork;
+
+    @Getter
+    ITrainableNeuralNet threadCurrentNetwork;
+
+    @Getter
+    final ITrainableNeuralNet globalCurrentNetwork;
+
+    public SyncNetworkHandler(ITrainableNeuralNet network) {
+        globalCurrentNetwork = network;
+        targetNetwork = network.clone();
+
+        // In sync setup, the thread current and the global current is the same network
+        threadCurrentNetwork = network;
+    }
+
+    @Override
+    public void resetForNewBuild() {
+        // Do Nothing
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/IActionSchema.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/IActionSchema.java
@@ -19,6 +19,8 @@ import lombok.Value;
 
 // Work in progress
 public interface IActionSchema<ACTION> {
+    int getActionSpaceSize();
+
     ACTION getNoOp();
 
     // Review: A schema should be data-only and not have behavior

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/IntegerActionSchema.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/environment/IntegerActionSchema.java
@@ -15,13 +15,16 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.environment;
 
+import lombok.Getter;
 import org.nd4j.linalg.api.rng.Random;
 import org.nd4j.linalg.factory.Nd4j;
 
 // Work in progress
 public class IntegerActionSchema implements IActionSchema<Integer> {
 
-    private final int numActions;
+    @Getter
+    private final int actionSpaceSize;
+
     private final int noOpAction;
     private final Random rnd;
 
@@ -30,7 +33,7 @@ public class IntegerActionSchema implements IActionSchema<Integer> {
     }
 
     public IntegerActionSchema(int numActions, int noOpAction, Random rnd) {
-        this.numActions = numActions;
+        this.actionSpaceSize = numActions;
         this.noOpAction = noOpAction;
         this.rnd = rnd;
     }
@@ -42,6 +45,6 @@ public class IntegerActionSchema implements IActionSchema<Integer> {
 
     @Override
     public Integer getRandomAction() {
-        return rnd.nextInt(numActions);
+        return rnd.nextInt(actionSpaceSize);
     }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/experience/ReplayMemoryExperienceHandler.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/experience/ReplayMemoryExperienceHandler.java
@@ -15,7 +15,10 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.experience;
 
+import lombok.Builder;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.learning.sync.ExpReplay;
 import org.deeplearning4j.rl4j.learning.sync.IExpReplay;
 import org.deeplearning4j.rl4j.learning.sync.Transition;
@@ -47,8 +50,8 @@ public class ReplayMemoryExperienceHandler<A> implements ExperienceHandler<A, Tr
         this.batchSize = expReplay.getDesignatedBatchSize();
     }
 
-    public ReplayMemoryExperienceHandler(int maxReplayMemorySize, int batchSize, Random random) {
-        this(new ExpReplay<A>(maxReplayMemorySize, batchSize, random));
+    public ReplayMemoryExperienceHandler(Configuration configuration, Random random) {
+        this(new ExpReplay<A>(configuration.maxReplayMemorySize, configuration.batchSize, random));
     }
 
     public void addExperience(Observation observation, A action, double reward, boolean isTerminal) {
@@ -91,28 +94,19 @@ public class ReplayMemoryExperienceHandler<A> implements ExperienceHandler<A, Tr
         }
     }
 
-    public class Builder {
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        /**
+         * The maximum replay memory size. Default is 150000
+         */
+        @Builder.Default
         private int maxReplayMemorySize = DEFAULT_MAX_REPLAY_MEMORY_SIZE;
+
+        /**
+         * The size of training batches. Default is 32.
+         */
+        @Builder.Default
         private int batchSize = DEFAULT_BATCH_SIZE;
-        private Random random = Nd4j.getRandom();
-
-        public Builder maxReplayMemorySize(int value) {
-            maxReplayMemorySize = value;
-            return this;
-        }
-
-        public Builder batchSize(int value) {
-            batchSize = value;
-            return this;
-        }
-
-        public Builder random(Random value) {
-            random = value;
-            return this;
-        }
-
-        public ReplayMemoryExperienceHandler<A> build() {
-            return new ReplayMemoryExperienceHandler<A>(maxReplayMemorySize, batchSize, random);
-        }
     }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/experience/StateActionExperienceHandler.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/experience/StateActionExperienceHandler.java
@@ -15,6 +15,9 @@
  ******************************************************************************/
 package org.deeplearning4j.rl4j.experience;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.rl4j.observation.Observation;
 
 import java.util.ArrayList;
@@ -29,13 +32,14 @@ import java.util.List;
  * @author Alexandre Boulanger
  */
 public class StateActionExperienceHandler<A> implements ExperienceHandler<A, StateActionPair<A>> {
+    private static final int DEFAULT_BATCH_SIZE = 8;
 
     private final int batchSize;
 
     private boolean isFinalObservationSet;
 
-    public StateActionExperienceHandler(int batchSize) {
-        this.batchSize = batchSize;
+    public StateActionExperienceHandler(Configuration configuration) {
+        this.batchSize = configuration.getBatchSize();
     }
 
     private List<StateActionPair<A>> stateActionPairs = new ArrayList<>();
@@ -79,4 +83,13 @@ public class StateActionExperienceHandler<A> implements ExperienceHandler<A, Sta
         isFinalObservationSet = false;
     }
 
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        /**
+         * The default training batch size. Default is 8.
+         */
+        @Builder.Default
+        private int batchSize = DEFAULT_BATCH_SIZE;
+    }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscrete.java
@@ -62,7 +62,10 @@ public abstract class AsyncThreadDiscrete<OBSERVATION extends Encodable, NN exte
             current = (NN) asyncGlobal.getTarget().clone();
         }
 
-        experienceHandler = new StateActionExperienceHandler(getNStep());
+        StateActionExperienceHandler.Configuration experienceHandlerConfiguration = StateActionExperienceHandler.Configuration.builder()
+            .batchSize(getNStep())
+            .build();
+        experienceHandler = new StateActionExperienceHandler(experienceHandlerConfiguration);
     }
 
     private int getNStep() {

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/DQNPolicy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/DQNPolicy.java
@@ -18,6 +18,7 @@ package org.deeplearning4j.rl4j.policy;
 
 import lombok.AllArgsConstructor;
 import org.deeplearning4j.rl4j.learning.Learning;
+import org.deeplearning4j.rl4j.network.IOutputNeuralNet;
 import org.deeplearning4j.rl4j.network.dqn.DQN;
 import org.deeplearning4j.rl4j.network.dqn.IDQN;
 import org.deeplearning4j.rl4j.space.Encodable;
@@ -37,14 +38,14 @@ import java.io.IOException;
 @AllArgsConstructor
 public class DQNPolicy<OBSERVATION> extends Policy<Integer> {
 
-    final private IDQN dqn;
+    final private IOutputNeuralNet neuralNet;
 
     public static <OBSERVATION extends Encodable> DQNPolicy<OBSERVATION> load(String path) throws IOException {
         return new DQNPolicy<>(DQN.load(path));
     }
 
-    public IDQN getNeuralNet() {
-        return dqn;
+    public IOutputNeuralNet getNeuralNet() {
+        return neuralNet;
     }
 
     @Override
@@ -53,12 +54,13 @@ public class DQNPolicy<OBSERVATION> extends Policy<Integer> {
     }
 
     public Integer nextAction(INDArray input) {
-        INDArray output = dqn.output(input);
+        INDArray output = neuralNet.output(input);
         return Learning.getMaxAction(output);
     }
 
     public void save(String filename) throws IOException {
-        dqn.save(filename);
+        // TODO: refac load & save. Code below should continue to work in the meantime because it's only called by the lecacy code and it's only using a DQN network with DQNPolicy
+        ((IDQN)neuralNet).save(filename);
     }
 
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
@@ -18,12 +18,14 @@
 package org.deeplearning4j.rl4j.policy;
 
 import lombok.Builder;
+import lombok.Data;
 import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.rl4j.environment.IActionSchema;
 import org.deeplearning4j.rl4j.learning.IEpochTrainer;
 import org.deeplearning4j.rl4j.mdp.MDP;
-import org.deeplearning4j.rl4j.network.NeuralNet;
+import org.deeplearning4j.rl4j.network.IOutputNeuralNet;
 import org.deeplearning4j.rl4j.observation.Observation;
 import org.deeplearning4j.rl4j.space.ActionSpace;
 import org.deeplearning4j.rl4j.space.Encodable;
@@ -45,7 +47,7 @@ import org.nd4j.linalg.factory.Nd4j;
 public class EpsGreedy<A> extends Policy<A> {
 
     final private INeuralNetPolicy<A> policy;
-    final private int updateStart;
+    final private int annealingStart;
     final private int epsilonNbStep;
     final private Random rnd;
     final private double minEpsilon;
@@ -61,14 +63,14 @@ public class EpsGreedy<A> extends Policy<A> {
     @Deprecated
     public <OBSERVATION extends Encodable, AS extends ActionSpace<A>> EpsGreedy(Policy<A> policy,
                                                                                 MDP<Encodable, A, ActionSpace<A>> mdp,
-                                                                                int updateStart,
+                                                                                int annealingStart,
                                                                                 int epsilonNbStep,
                                                                                 Random rnd,
                                                                                 double minEpsilon,
                                                                                 IEpochTrainer learning) {
         this.policy = policy;
         this.mdp = mdp;
-        this.updateStart = updateStart;
+        this.annealingStart = annealingStart;
         this.epsilonNbStep = epsilonNbStep;
         this.rnd = rnd;
         this.minEpsilon = minEpsilon;
@@ -77,17 +79,17 @@ public class EpsGreedy<A> extends Policy<A> {
         this.actionSchema = null;
     }
 
-    public EpsGreedy(@NonNull Policy<A> policy, @NonNull IActionSchema<A> actionSchema, double minEpsilon, int updateStart, int epsilonNbStep) {
-        this(policy, actionSchema, minEpsilon, updateStart, epsilonNbStep, null);
+    public EpsGreedy(@NonNull Policy<A> policy, @NonNull IActionSchema<A> actionSchema, double minEpsilon, int annealingStart, int epsilonNbStep) {
+        this(policy, actionSchema, minEpsilon, annealingStart, epsilonNbStep, null);
     }
 
     @Builder
-    public EpsGreedy(@NonNull INeuralNetPolicy<A> policy, @NonNull IActionSchema<A> actionSchema, double minEpsilon, int updateStart, int epsilonNbStep, Random rnd) {
+    public EpsGreedy(@NonNull INeuralNetPolicy<A> policy, @NonNull IActionSchema<A> actionSchema, double minEpsilon, int annealingStart, int epsilonNbStep, Random rnd) {
         this.policy = policy;
 
         this.rnd = rnd == null ? Nd4j.getRandom() : rnd;
         this.minEpsilon = minEpsilon;
-        this.updateStart = updateStart;
+        this.annealingStart = annealingStart;
         this.epsilonNbStep = epsilonNbStep;
         this.actionSchema = actionSchema;
 
@@ -95,7 +97,11 @@ public class EpsGreedy<A> extends Policy<A> {
         this.learning = null;
     }
 
-    public NeuralNet getNeuralNet() {
+    public EpsGreedy(INeuralNetPolicy<A> policy, IActionSchema<A> actionSchema, @NonNull Configuration configuration, Random rnd) {
+        this(policy, actionSchema, configuration.getMinEpsilon(), configuration.getAnnealingStart(), configuration.getEpsilonNbStep(), rnd);
+    }
+
+    public IOutputNeuralNet getNeuralNet() {
         return policy.getNeuralNet();
     }
 
@@ -141,6 +147,16 @@ public class EpsGreedy<A> extends Policy<A> {
 
     public double getEpsilon() {
         int step = actionSchema != null ? annealingStep : learning.getStepCount();
-        return Math.min(1.0, Math.max(minEpsilon, 1.0 - (step - updateStart) * 1.0 / epsilonNbStep));
+        return Math.min(1.0, Math.max(minEpsilon, 1.0 - (step - annealingStart) * 1.0 / epsilonNbStep));
+    }
+
+    @SuperBuilder
+    @Data
+    public static class Configuration {
+        @Builder.Default
+        final int annealingStart = 0;
+
+        final int epsilonNbStep;
+        final double minEpsilon;
     }
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/INeuralNetPolicy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/INeuralNetPolicy.java
@@ -1,7 +1,7 @@
 package org.deeplearning4j.rl4j.policy;
 
-import org.deeplearning4j.rl4j.network.NeuralNet;
+import org.deeplearning4j.rl4j.network.IOutputNeuralNet;
 
 public interface INeuralNetPolicy<ACTION> extends IPolicy<ACTION> {
-    NeuralNet getNeuralNet();
+    IOutputNeuralNet getNeuralNet();
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/Policy.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/Policy.java
@@ -16,15 +16,16 @@
 
 package org.deeplearning4j.rl4j.policy;
 
+import lombok.experimental.SuperBuilder;
 import org.deeplearning4j.gym.StepReply;
 import org.deeplearning4j.rl4j.learning.HistoryProcessor;
 import org.deeplearning4j.rl4j.learning.IHistoryProcessor;
 import org.deeplearning4j.rl4j.learning.Learning;
 import org.deeplearning4j.rl4j.mdp.MDP;
-import org.deeplearning4j.rl4j.network.NeuralNet;
-import org.deeplearning4j.rl4j.space.Encodable;
+import org.deeplearning4j.rl4j.network.IOutputNeuralNet;
 import org.deeplearning4j.rl4j.observation.Observation;
 import org.deeplearning4j.rl4j.space.ActionSpace;
+import org.deeplearning4j.rl4j.space.Encodable;
 import org.deeplearning4j.rl4j.util.LegacyMDPWrapper;
 
 /**
@@ -36,7 +37,7 @@ import org.deeplearning4j.rl4j.util.LegacyMDPWrapper;
  */
 public abstract class Policy<A> implements INeuralNetPolicy<A> {
 
-    public abstract NeuralNet getNeuralNet();
+    public abstract IOutputNeuralNet getNeuralNet();
 
     public abstract A nextAction(Observation obs);
 
@@ -106,5 +107,4 @@ public abstract class Policy<A> implements INeuralNetPolicy<A> {
 
         return new Learning.InitMdp(0, observation, reward);
     }
-
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/trainer/ITrainer.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/trainer/ITrainer.java
@@ -13,31 +13,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
-package org.deeplearning4j.rl4j.network;
-
-import org.deeplearning4j.rl4j.observation.Observation;
-import org.nd4j.linalg.api.ndarray.INDArray;
+package org.deeplearning4j.rl4j.trainer;
 
 /**
- * An interface defining the output aspect of a {@link NeuralNet}.
+ * An interface describing the behavior of all trainers
  */
-public interface IOutputNeuralNet {
-    /**
-     * Compute the output for the supplied observation.
-     * @param observation An {@link Observation}
-     * @return The ouptut of the network
-     */
-    INDArray output(Observation observation);
-
-    /**
-     * Compute the output for the supplied batch.
-     * @param batch
-     * @return The ouptut of the network
-     */
-    INDArray output(INDArray batch);
-
-    /**
-     * Clear the neural net of any previous state
-     */
-    void reset();
+public interface ITrainer {
+    void train();
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/trainer/SyncTrainer.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/trainer/SyncTrainer.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Konduit K.K.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package org.deeplearning4j.rl4j.trainer;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+
+import java.util.function.Predicate;
+
+// TODO: Add listeners & events once AsyncTrainer is implemented
+
+/**
+ * A {@link ITrainer} implementation that will create a single {@link IAgentLearner} and perform the training in a
+ * synchronized setup, until a stopping condition is met.
+ *
+ * @param <ACTION> The type of the actions expected by the environment
+ */
+public class SyncTrainer<ACTION> implements ITrainer {
+
+    private final Predicate<SyncTrainer<ACTION>> stoppingCondition;
+
+    @Getter
+    private int episodeCount;
+
+    @Getter
+    final IAgentLearner<ACTION> agentLearner;
+
+    /**
+     * Build a SyncTrainer that will train until a stopping condition is met.
+     * @param agentLearnerBuilder the builder that will be used to create the agent-learner instance
+     * @param stoppingCondition the training will stop when this condition evaluates to true
+     */
+    @lombok.Builder
+    public SyncTrainer(@NonNull Builder<IAgentLearner<ACTION>> agentLearnerBuilder,
+                       @NonNull Predicate<SyncTrainer<ACTION>> stoppingCondition) {
+        this.stoppingCondition = stoppingCondition;
+        agentLearner = agentLearnerBuilder.build();
+    }
+
+    /**
+     * Perform the training
+     */
+    public void train() {
+        while (!stoppingCondition.test(this)) {
+            agentLearner.run();
+            ++episodeCount;
+        }
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/AgentLearnerTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/AgentLearnerTest.java
@@ -43,9 +43,10 @@ public class AgentLearnerTest {
     @Test
     public void when_episodeIsStarted_expect_learningBehaviorHandleEpisodeStartCalled() {
         // Arrange
-        AgentLearner<Integer> sut = AgentLearner.builder(environmentMock, transformProcessMock, policyMock, learningBehaviorMock)
+        AgentLearner.Configuration configuration = AgentLearner.Configuration.builder()
                 .maxEpisodeSteps(3)
                 .build();
+        AgentLearner<Integer> sut = new AgentLearner(environmentMock, transformProcessMock, policyMock, configuration, null, learningBehaviorMock);
 
         Schema schema = new Schema(new IntegerActionSchema(0, -1));
         when(environmentMock.reset()).thenReturn(new HashMap<>());
@@ -67,9 +68,10 @@ public class AgentLearnerTest {
     @Test
     public void when_runIsCalled_expect_experienceHandledWithLearningBehavior() {
         // Arrange
-        AgentLearner<Integer> sut = AgentLearner.builder(environmentMock, transformProcessMock, policyMock, learningBehaviorMock)
+        AgentLearner.Configuration configuration = AgentLearner.Configuration.builder()
                 .maxEpisodeSteps(4)
                 .build();
+        AgentLearner<Integer> sut = new AgentLearner(environmentMock, transformProcessMock, policyMock, configuration, null, learningBehaviorMock);
 
         Schema schema = new Schema(new IntegerActionSchema(0, -1));
         when(environmentMock.getSchema()).thenReturn(schema);
@@ -127,9 +129,10 @@ public class AgentLearnerTest {
     @Test
     public void when_runIsCalledMultipleTimes_expect_totalStepCountCorrect() {
         // Arrange
-        AgentLearner<Integer> sut = AgentLearner.builder(environmentMock, transformProcessMock, policyMock, learningBehaviorMock)
+        AgentLearner.Configuration configuration = AgentLearner.Configuration.builder()
                 .maxEpisodeSteps(4)
                 .build();
+        AgentLearner<Integer> sut = new AgentLearner(environmentMock, transformProcessMock, policyMock, configuration, null, learningBehaviorMock);
 
         Schema schema = new Schema(new IntegerActionSchema(0, -1));
         when(environmentMock.getSchema()).thenReturn(schema);
@@ -166,9 +169,10 @@ public class AgentLearnerTest {
     @Test
     public void when_runIsCalledMultipleTimes_expect_rewardSentToLearningBehaviorToBeCorrect() {
         // Arrange
-        AgentLearner<Integer> sut = AgentLearner.builder(environmentMock, transformProcessMock, policyMock, learningBehaviorMock)
+        AgentLearner.Configuration configuration = AgentLearner.Configuration.builder()
                 .maxEpisodeSteps(4)
                 .build();
+        AgentLearner<Integer> sut = new AgentLearner(environmentMock, transformProcessMock, policyMock, configuration, null, learningBehaviorMock);
 
         Schema schema = new Schema(new IntegerActionSchema(0, -1));
         when(environmentMock.getSchema()).thenReturn(schema);

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/AgentTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/AgentTest.java
@@ -33,7 +33,7 @@ public class AgentTest {
     @Test
     public void when_buildingWithNullEnvironment_expect_exception() {
         try {
-            Agent.builder(null, null, null).build();
+            new Agent(null, null, null, null, null);
             fail("NullPointerException should have been thrown");
         } catch (NullPointerException exception) {
             String expectedMessage = "environment is marked non-null but is null";
@@ -46,7 +46,7 @@ public class AgentTest {
     @Test
     public void when_buildingWithNullTransformProcess_expect_exception() {
         try {
-            Agent.builder(environmentMock, null, null).build();
+            new Agent(environmentMock, null, null, null, null);
             fail("NullPointerException should have been thrown");
         } catch (NullPointerException exception) {
             String expectedMessage = "transformProcess is marked non-null but is null";
@@ -59,7 +59,7 @@ public class AgentTest {
     @Test
     public void when_buildingWithNullPolicy_expect_exception() {
         try {
-            Agent.builder(environmentMock, transformProcessMock, null).build();
+            new Agent(environmentMock, transformProcessMock, null, null, null);
             fail("NullPointerException should have been thrown");
         } catch (NullPointerException exception) {
             String expectedMessage = "policy is marked non-null but is null";
@@ -70,14 +70,28 @@ public class AgentTest {
     }
 
     @Test
+    public void when_buildingWithNullConfiguration_expect_exception() {
+        try {
+            new Agent(environmentMock, transformProcessMock, policyMock, null, null);
+            fail("NullPointerException should have been thrown");
+        } catch (NullPointerException exception) {
+            String expectedMessage = "configuration is marked non-null but is null";
+            String actualMessage = exception.getMessage();
+
+            assertTrue(actualMessage.contains(expectedMessage));
+        }
+    }
+
+    @Test
     public void when_buildingWithInvalidMaxSteps_expect_exception() {
         try {
-            Agent.builder(environmentMock, transformProcessMock, policyMock)
-                    .maxEpisodeSteps(0)
-                    .build();
+            Agent.Configuration configuration = Agent.Configuration.builder()
+                .maxEpisodeSteps(0)
+                .build();
+            new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
             fail("IllegalArgumentException should have been thrown");
         } catch (IllegalArgumentException exception) {
-            String expectedMessage = "maxEpisodeSteps must be greater than 0, got [0]";
+            String expectedMessage = "Configuration: maxEpisodeSteps must be null (no maximum) or greater than 0, got [0]";
             String actualMessage = exception.getMessage();
 
             assertTrue(actualMessage.contains(expectedMessage));
@@ -87,9 +101,8 @@ public class AgentTest {
     @Test
     public void when_buildingWithId_expect_idSetInAgent() {
         // Arrange
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
-                .id("TestAgent")
-                .build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, "TestAgent");
 
         // Assert
         assertEquals("TestAgent", sut.getId());
@@ -106,8 +119,8 @@ public class AgentTest {
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
         when(policyMock.nextAction(any(Observation.class))).thenReturn(1);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
-                .build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), anyInt())).thenReturn(AgentListener.ListenerResponse.STOP);
         sut.addListener(listenerMock);
@@ -134,7 +147,8 @@ public class AgentTest {
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
         when(environmentMock.isEpisodeFinished()).thenReturn(true);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock).build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
         Agent spy = Mockito.spy(sut);
 
         // Act
@@ -155,7 +169,8 @@ public class AgentTest {
 
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock).build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         when(listenerMock.onBeforeEpisode(any(Agent.class))).thenReturn(AgentListener.ListenerResponse.STOP);
         sut.addListener(listenerMock);
@@ -182,8 +197,8 @@ public class AgentTest {
 
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
-                .build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         final Agent spy = Mockito.spy(sut);
 
@@ -212,9 +227,10 @@ public class AgentTest {
 
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(3)
                 .build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         final Agent spy = Mockito.spy(sut);
 
@@ -242,8 +258,8 @@ public class AgentTest {
 
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(Observation.SkippedObservation);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
-                .build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), any())).thenReturn(AgentListener.ListenerResponse.STOP);
         sut.addListener(listenerMock);
@@ -267,8 +283,8 @@ public class AgentTest {
 
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(Observation.SkippedObservation);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
-                .build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), any())).thenReturn(AgentListener.ListenerResponse.STOP);
         sut.addListener(listenerMock);
@@ -294,9 +310,10 @@ public class AgentTest {
         when(policyMock.nextAction(any(Observation.class)))
                 .thenAnswer(invocation -> (int)((Observation)invocation.getArgument(0)).getData().getDouble(0));
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(3)
                 .build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         Agent spy = Mockito.spy(sut);
 
@@ -334,7 +351,8 @@ public class AgentTest {
 
         when(transformProcessMock.transform(any(Map.class), anyInt(), anyBoolean())).thenReturn(new Observation(Nd4j.create(new double[] { 123.0 })));
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock).build();
+        Agent.Configuration configuration = Agent.Configuration.builder().build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         when(listenerMock.onBeforeStep(any(Agent.class), any(Observation.class), any())).thenReturn(AgentListener.ListenerResponse.STOP);
         sut.addListener(listenerMock);
@@ -364,9 +382,10 @@ public class AgentTest {
 
         when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(1)
                 .build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         // Act
         sut.run();
@@ -387,9 +406,10 @@ public class AgentTest {
 
         when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(1)
                 .build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
 
         // Act
         sut.run();
@@ -412,9 +432,10 @@ public class AgentTest {
 
         when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(1)
                 .build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
         Agent spy = Mockito.spy(sut);
 
         // Act
@@ -437,9 +458,10 @@ public class AgentTest {
 
         when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(1)
                 .build();
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
         when(listenerMock.onAfterStep(any(Agent.class), any(StepResult.class))).thenReturn(AgentListener.ListenerResponse.STOP);
         sut.addListener(listenerMock);
 
@@ -465,10 +487,11 @@ public class AgentTest {
 
         when(policyMock.nextAction(any(Observation.class))).thenReturn(123);
 
-        Agent sut = Agent.builder(environmentMock, transformProcessMock, policyMock)
+        Agent.Configuration configuration = Agent.Configuration.builder()
                 .maxEpisodeSteps(1)
                 .build();
-
+        Agent sut = new Agent(environmentMock, transformProcessMock, policyMock, configuration, null);
+        sut.addListener(listenerMock);
         Agent spy = Mockito.spy(sut);
 
         // Act
@@ -476,5 +499,6 @@ public class AgentTest {
 
         // Assert
         verify(spy, times(1)).onAfterEpisode();
+        verify(listenerMock, times(1)).onAfterEpisode(any());
     }
 }

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/algorithm/NStepQLearningTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/algorithm/NStepQLearningTest.java
@@ -38,7 +38,10 @@ public class NStepQLearningTest {
         when(currentMock.output(any(INDArray.class))).thenAnswer(invocation -> invocation.getArgument(0, INDArray.class).mul(-1.0));
         when(targetMock.output(any(INDArray.class))).thenAnswer(invocation -> invocation.getArgument(0, INDArray.class).mul(-2.0));
 
-        sut = new NStepQLearning(currentMock, targetMock, ACTION_SPACE_SIZE, gamma);
+        NStepQLearning.Configuration configuration = NStepQLearning.Configuration.builder()
+            .gamma(gamma)
+            .build();
+        sut = new NStepQLearning(currentMock, targetMock, ACTION_SPACE_SIZE, configuration);
     }
 
     @Test

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/DoubleDQNTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/DoubleDQNTest.java
@@ -30,6 +30,9 @@ public class DoubleDQNTest {
     @Mock
     IOutputNeuralNet targetQNetworkMock;
 
+    private final BaseTransitionTDAlgorithm.Configuration configuration = BaseTransitionTDAlgorithm.Configuration.builder()
+            .gamma(0.5)
+            .build();
 
     @Before
     public void setup() {
@@ -49,7 +52,7 @@ public class DoubleDQNTest {
             }
         };
 
-        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN(qNetworkMock, targetQNetworkMock, 0.5);
+        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN(qNetworkMock, targetQNetworkMock, configuration);
 
         // Act
         FeaturesLabels result = sut.compute(transitions);
@@ -73,7 +76,7 @@ public class DoubleDQNTest {
             }
         };
 
-        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN(qNetworkMock, targetQNetworkMock, 0.5);
+        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN(qNetworkMock, targetQNetworkMock, configuration);
 
         // Act
         FeaturesLabels result = sut.compute(transitions);
@@ -101,7 +104,7 @@ public class DoubleDQNTest {
             }
         };
 
-        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN sut = new DoubleDQN(qNetworkMock, targetQNetworkMock, 0.5);
+        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN sut = new DoubleDQN(qNetworkMock, targetQNetworkMock, configuration);
 
         // Act
         FeaturesLabels result = sut.compute(transitions);

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/StandardDQNTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/algorithm/dqn/StandardDQNTest.java
@@ -30,6 +30,9 @@ public class StandardDQNTest {
     @Mock
     IOutputNeuralNet targetQNetworkMock;
 
+    private final BaseTransitionTDAlgorithm.Configuration configuration = BaseTransitionTDAlgorithm.Configuration.builder()
+            .gamma(0.5)
+            .build();
 
     @Before
     public void setup() {
@@ -49,7 +52,7 @@ public class StandardDQNTest {
             }
         };
 
-        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN(qNetworkMock, targetQNetworkMock, 0.5);
+        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN(qNetworkMock, targetQNetworkMock, configuration);
 
         // Act
         FeaturesLabels result = sut.compute(transitions);
@@ -71,7 +74,7 @@ public class StandardDQNTest {
             }
         };
 
-        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN(qNetworkMock, targetQNetworkMock, 0.5);
+        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN sut = new org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN(qNetworkMock, targetQNetworkMock, configuration);
 
         // Act
         FeaturesLabels result = sut.compute(transitions);
@@ -97,7 +100,7 @@ public class StandardDQNTest {
             }
         };
 
-        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN sut = new StandardDQN(qNetworkMock, targetQNetworkMock, 0.5);
+        org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.StandardDQN sut = new StandardDQN(qNetworkMock, targetQNetworkMock, configuration);
 
         // Act
         FeaturesLabels result = sut.compute(transitions);

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/update/updater/GradientsNeuralNetUpdaterTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/update/updater/GradientsNeuralNetUpdaterTest.java
@@ -21,7 +21,9 @@ public class GradientsNeuralNetUpdaterTest {
     @Test
     public void when_callingUpdate_expect_currentUpdatedAndtargetNotChanged() {
         // Arrange
-        GradientsNeuralNetUpdater sut = new GradientsNeuralNetUpdater(currentMock, targetMock, Integer.MAX_VALUE);
+        GradientsNeuralNetUpdater.Configuration configuration = GradientsNeuralNetUpdater.Configuration.builder()
+                .build();
+        GradientsNeuralNetUpdater sut = new GradientsNeuralNetUpdater(currentMock, targetMock, configuration);
         Gradients gradients = new Gradients(10);
 
         // Act
@@ -35,7 +37,10 @@ public class GradientsNeuralNetUpdaterTest {
     @Test
     public void when_callingUpdate_expect_targetUpdatedFromCurrentAtFrequency() {
         // Arrange
-        GradientsNeuralNetUpdater sut = new GradientsNeuralNetUpdater(currentMock, targetMock, 3);
+        GradientsNeuralNetUpdater.Configuration configuration = GradientsNeuralNetUpdater.Configuration.builder()
+                .targetUpdateFrequency(3)
+                .build();
+        GradientsNeuralNetUpdater sut = new GradientsNeuralNetUpdater(currentMock, targetMock, configuration);
         Gradients gradients = new Gradients(10);
 
         // Act

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/update/updater/LabelsNeuralNetUpdaterTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/agent/learning/update/updater/LabelsNeuralNetUpdaterTest.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.rl4j.agent.learning.update.updater;
 
+import org.deeplearning4j.rl4j.agent.Agent;
 import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
 import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
 import org.junit.Test;
@@ -7,6 +8,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -19,9 +22,29 @@ public class LabelsNeuralNetUpdaterTest {
     ITrainableNeuralNet targetMock;
 
     @Test
-    public void when_callingUpdate_expect_currentUpdatedAndtargetNotChanged() {
+    public void when_callingUpdateWithTargetUpdateFrequencyAt0_expect_Exception() {
         // Arrange
-        LabelsNeuralNetUpdater sut = new LabelsNeuralNetUpdater(currentMock, targetMock, Integer.MAX_VALUE);
+        LabelsNeuralNetUpdater.Configuration configuration = LabelsNeuralNetUpdater.Configuration.builder()
+                .targetUpdateFrequency(0)
+                .build();
+        try {
+            LabelsNeuralNetUpdater sut = new LabelsNeuralNetUpdater(currentMock, targetMock, configuration);
+            fail("IllegalArgumentException should have been thrown");
+        } catch (IllegalArgumentException exception) {
+            String expectedMessage = "Configuration: targetUpdateFrequency must be greater than 0, got:  [0]";
+            String actualMessage = exception.getMessage();
+
+            assertTrue(actualMessage.contains(expectedMessage));
+        }
+
+    }
+
+    @Test
+    public void when_callingUpdate_expect_currentUpdatedAndTargetNotChanged() {
+        // Arrange
+        LabelsNeuralNetUpdater.Configuration configuration = LabelsNeuralNetUpdater.Configuration.builder()
+                .build();
+        LabelsNeuralNetUpdater sut = new LabelsNeuralNetUpdater(currentMock, targetMock, configuration);
         FeaturesLabels featureLabels = new FeaturesLabels(null);
 
         // Act
@@ -35,7 +58,10 @@ public class LabelsNeuralNetUpdaterTest {
     @Test
     public void when_callingUpdate_expect_targetUpdatedFromCurrentAtFrequency() {
         // Arrange
-        LabelsNeuralNetUpdater sut = new LabelsNeuralNetUpdater(currentMock, targetMock, 3);
+        LabelsNeuralNetUpdater.Configuration configuration = LabelsNeuralNetUpdater.Configuration.builder()
+                .targetUpdateFrequency(3)
+                .build();
+        LabelsNeuralNetUpdater sut = new LabelsNeuralNetUpdater(currentMock, targetMock, configuration);
         FeaturesLabels featureLabels = new FeaturesLabels(null);
 
         // Act

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/builder/BaseAgentLearnerBuilderTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/builder/BaseAgentLearnerBuilderTest.java
@@ -1,0 +1,92 @@
+package org.deeplearning4j.rl4j.builder;
+
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.AgentLearner;
+import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
+import org.deeplearning4j.rl4j.agent.learning.update.updater.INeuralNetUpdater;
+import org.deeplearning4j.rl4j.environment.Environment;
+import org.deeplearning4j.rl4j.experience.ExperienceHandler;
+import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
+import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
+import org.deeplearning4j.rl4j.policy.IPolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseAgentLearnerBuilderTest {
+    @Mock
+    BaseAgentLearnerBuilder.Configuration configuration;
+
+    @Mock
+    ITrainableNeuralNet neuralNet;
+
+    @Mock
+    Builder<Environment<Integer>> environmentBuilder;
+
+    @Mock
+    Builder<TransformProcess> transformProcessBuilder;
+
+    @Mock
+    IUpdateAlgorithm updateAlgorithmMock;
+
+    @Mock
+    INeuralNetUpdater neuralNetUpdaterMock;
+
+    @Mock
+    ExperienceHandler experienceHandlerMock;
+
+    @Mock
+    Environment environmentMock;
+
+    @Mock
+    IPolicy policyMock;
+
+    @Mock
+    TransformProcess transformProcessMock;
+
+    BaseAgentLearnerBuilder sut;
+
+    @Before
+    public void setup() {
+        sut = mock(
+                BaseAgentLearnerBuilder.class,
+                Mockito.withSettings()
+                        .useConstructor(configuration, neuralNet, environmentBuilder, transformProcessBuilder)
+                        .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+        );
+
+        AgentLearner.Configuration agentLearnerConfiguration = AgentLearner.Configuration.builder().maxEpisodeSteps(200).build();
+
+        when(sut.buildUpdateAlgorithm()).thenReturn(updateAlgorithmMock);
+        when(sut.buildNeuralNetUpdater()).thenReturn(neuralNetUpdaterMock);
+        when(sut.buildExperienceHandler()).thenReturn(experienceHandlerMock);
+        when(environmentBuilder.build()).thenReturn(environmentMock);
+        when(transformProcessBuilder.build()).thenReturn(transformProcessMock);
+        when(sut.buildPolicy()).thenReturn(policyMock);
+        when(configuration.getAgentLearnerConfiguration()).thenReturn(agentLearnerConfiguration);
+    }
+
+    @Test
+    public void when_buildingAgentLearner_expect_dependenciesAndAgentLearnerIsBuilt() {
+        // Arrange
+
+        // Act
+        sut.build();
+
+        // Assert
+        verify(environmentBuilder, times(1)).build();
+        verify(transformProcessBuilder, times(1)).build();
+        verify(sut, times(1)).buildPolicy();
+        verify(sut, times(1)).buildExperienceHandler();
+        verify(sut, times(1)).buildUpdateAlgorithm();
+        verify(sut, times(1)).buildNeuralNetUpdater();
+        verify(sut, times(1)).buildAgentLearner();
+    }
+
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/experience/ReplayMemoryExperienceHandlerTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/experience/ReplayMemoryExperienceHandlerTest.java
@@ -21,6 +21,13 @@ public class ReplayMemoryExperienceHandlerTest {
     @Mock
     IExpReplay<Integer> expReplayMock;
 
+    private ReplayMemoryExperienceHandler.Configuration buildConfiguration() {
+        return ReplayMemoryExperienceHandler.Configuration.builder()
+                .maxReplayMemorySize(10)
+                .batchSize(5)
+                .build();
+    }
+
     @Test
     public void when_addingFirstExperience_expect_notAddedToStoreBeforeNextObservationIsAdded() {
         // Arrange
@@ -87,7 +94,7 @@ public class ReplayMemoryExperienceHandlerTest {
     @Test
     public void when_addingExperience_expect_getTrainingBatchSizeReturnSize() {
         // Arrange
-        ReplayMemoryExperienceHandler sut = new ReplayMemoryExperienceHandler(10, 5, Nd4j.getRandom());
+        ReplayMemoryExperienceHandler sut = new ReplayMemoryExperienceHandler(buildConfiguration(), Nd4j.getRandom());
         sut.addExperience(new Observation(Nd4j.create(new double[] { 1.0 })), 1, 1.0, false);
         sut.addExperience(new Observation(Nd4j.create(new double[] { 2.0 })), 2, 2.0, false);
         sut.setFinalObservation(new Observation(Nd4j.create(new double[] { 3.0 })));
@@ -102,7 +109,7 @@ public class ReplayMemoryExperienceHandlerTest {
     @Test
     public void when_experienceSizeIsSmallerThanBatchSize_expect_TrainingBatchIsNotReady() {
         // Arrange
-        ReplayMemoryExperienceHandler sut = new ReplayMemoryExperienceHandler(10, 5, Nd4j.getRandom());
+        ReplayMemoryExperienceHandler sut = new ReplayMemoryExperienceHandler(buildConfiguration(), Nd4j.getRandom());
         sut.addExperience(new Observation(Nd4j.create(new double[] { 1.0 })), 1, 1.0, false);
         sut.addExperience(new Observation(Nd4j.create(new double[] { 2.0 })), 2, 2.0, false);
         sut.setFinalObservation(new Observation(Nd4j.create(new double[] { 3.0 })));
@@ -116,7 +123,7 @@ public class ReplayMemoryExperienceHandlerTest {
     @Test
     public void when_experienceSizeIsGreaterOrEqualToBatchSize_expect_TrainingBatchIsReady() {
         // Arrange
-        ReplayMemoryExperienceHandler sut = new ReplayMemoryExperienceHandler(10, 5, Nd4j.getRandom());
+        ReplayMemoryExperienceHandler sut = new ReplayMemoryExperienceHandler(buildConfiguration(), Nd4j.getRandom());
         sut.addExperience(new Observation(Nd4j.create(new double[] { 1.0 })), 1, 1.0, false);
         sut.addExperience(new Observation(Nd4j.create(new double[] { 2.0 })), 2, 2.0, false);
         sut.addExperience(new Observation(Nd4j.create(new double[] { 3.0 })), 3, 3.0, false);

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/experience/StateActionExperienceHandlerTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/experience/StateActionExperienceHandlerTest.java
@@ -10,10 +10,16 @@ import static org.junit.Assert.*;
 
 public class StateActionExperienceHandlerTest {
 
+    private StateActionExperienceHandler.Configuration buildConfiguration(int batchSize) {
+        return StateActionExperienceHandler.Configuration.builder()
+                .batchSize(batchSize)
+                .build();
+    }
+
     @Test
     public void when_addingExperience_expect_generateTrainingBatchReturnsIt() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(Integer.MAX_VALUE);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(Integer.MAX_VALUE));
         sut.reset();
         Observation observation = new Observation(Nd4j.zeros(1));
         sut.addExperience(observation, 123, 234.0, true);
@@ -32,7 +38,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_addingMultipleExperiences_expect_generateTrainingBatchReturnsItInSameOrder() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(Integer.MAX_VALUE);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(Integer.MAX_VALUE));
         sut.reset();
         sut.addExperience(null, 1, 1.0, false);
         sut.addExperience(null, 2, 2.0, false);
@@ -51,7 +57,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_gettingExperience_expect_experienceStoreIsCleared() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(Integer.MAX_VALUE);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(Integer.MAX_VALUE));
         sut.reset();
         sut.addExperience(null, 1, 1.0, false);
 
@@ -67,7 +73,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_addingExperience_expect_getTrainingBatchSizeReturnSize() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(Integer.MAX_VALUE);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(Integer.MAX_VALUE));
         sut.reset();
         sut.addExperience(null, 1, 1.0, false);
         sut.addExperience(null, 2, 2.0, false);
@@ -83,7 +89,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_experienceIsEmpty_expect_TrainingBatchNotReady() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(5);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(5));
         sut.reset();
 
         // Act
@@ -96,7 +102,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_experienceSizeIsGreaterOrEqualToThanBatchSize_expect_TrainingBatchIsReady() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(5);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(5));
         sut.reset();
         sut.addExperience(null, 1, 1.0, false);
         sut.addExperience(null, 2, 2.0, false);
@@ -114,7 +120,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_experienceSizeIsSmallerThanBatchSizeButFinalObservationIsSet_expect_TrainingBatchIsReady() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(5);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(5));
         sut.reset();
         sut.addExperience(null, 1, 1.0, false);
         sut.addExperience(null, 2, 2.0, false);
@@ -130,7 +136,7 @@ public class StateActionExperienceHandlerTest {
     @Test
     public void when_experienceSizeIsZeroAndFinalObservationIsSet_expect_TrainingBatchIsNotReady() {
         // Arrange
-        StateActionExperienceHandler sut = new StateActionExperienceHandler(5);
+        StateActionExperienceHandler sut = new StateActionExperienceHandler(buildConfiguration(5));
         sut.reset();
         sut.setFinalObservation(null);
 

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscreteTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscreteTest.java
@@ -100,6 +100,8 @@ public class QLearningDiscreteTest {
         when(mockQlearningConfiguration.getRewardFactor()).thenReturn(rewardFactor);
         when(mockQlearningConfiguration.getExpRepMaxSize()).thenReturn(maxExperienceReplay);
         when(mockQlearningConfiguration.getSeed()).thenReturn(123L);
+        when(mockQlearningConfiguration.getTargetDqnUpdateFreq()).thenReturn(1);
+        when(mockDQN.clone()).thenReturn(mockDQN);
 
         if(learningBehavior != null) {
             qLearningDiscrete = mock(

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/trainer/SyncTrainerTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/trainer/SyncTrainerTest.java
@@ -1,0 +1,59 @@
+package org.deeplearning4j.rl4j.trainer;
+
+import org.apache.commons.lang3.builder.Builder;
+import org.deeplearning4j.rl4j.agent.IAgentLearner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SyncTrainerTest {
+
+    @Mock
+    IAgentLearner agentLearnerMock;
+
+    @Mock
+    Builder<IAgentLearner> agentLearnerBuilder;
+
+    SyncTrainer sut;
+
+    public void setup(Predicate<SyncTrainer> stoppingCondition) {
+        when(agentLearnerBuilder.build()).thenReturn(agentLearnerMock);
+
+        sut = new SyncTrainer(agentLearnerBuilder, stoppingCondition);
+    }
+
+    @Test
+    public void when_training_expect_stoppingConditionWillStopTraining() {
+        // Arrange
+        Predicate<SyncTrainer> stoppingCondition = t -> t.getEpisodeCount() >= 5; // Stop after 5 episodes
+        setup(stoppingCondition);
+
+        // Act
+        sut.train();
+
+        // Assert
+        assertEquals(5, sut.getEpisodeCount());
+    }
+
+    @Test
+    public void when_training_expect_agentIsRun() {
+        // Arrange
+        Predicate<SyncTrainer> stoppingCondition = t -> t.getEpisodeCount() >= 5; // Stop after 5 episodes
+        setup(stoppingCondition);
+
+        // Act
+        sut.train();
+
+        // Assert
+        verify(agentLearnerMock, times(5)).run();
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this PR, a `IAgentLearner` builder is added that should be able to build agent-learners for common scenarios. Presently, Double-DQN, Standard-DQN and NStepQLearning are available.
A basic synchronous trainer is also added that can use the builder above for common scenarios or any custom builder of `IAgentLearner` for specific needs.
Some async elements are introduced here but the agent-learner remain synchronous-only for the time being.

Also, I changed several classes to be 'Configuration'-based which makes it easier to create via builders.
And finally I added a few safety `@NonNull` here and there.

Note: If this PR is too big, I can split it no problem.

The code below will train with cartpole for 5000 episodes or when the agent-learner hits 200 points for 5 episodes in a row. 
It should stop arount episode 74 for DoubleDQN (on my setup) and episode 1242 for NStepQLearning
```
package org.deeplearning4j.rl4j;

import org.apache.commons.lang3.builder.Builder;
import org.datavec.api.transform.Operation;
import org.deeplearning4j.rl4j.agent.Agent;
import org.deeplearning4j.rl4j.agent.AgentLearner;
import org.deeplearning4j.rl4j.agent.IAgentLearner;
import org.deeplearning4j.rl4j.agent.learning.algorithm.IUpdateAlgorithm;
import org.deeplearning4j.rl4j.agent.learning.algorithm.NStepQLearning;
import org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.BaseTransitionTDAlgorithm;
import org.deeplearning4j.rl4j.agent.learning.algorithm.dqn.DoubleDQN;
import org.deeplearning4j.rl4j.agent.learning.behavior.ILearningBehavior;
import org.deeplearning4j.rl4j.agent.learning.behavior.LearningBehavior;
import org.deeplearning4j.rl4j.agent.learning.update.FeaturesLabels;
import org.deeplearning4j.rl4j.agent.learning.update.Gradients;
import org.deeplearning4j.rl4j.agent.learning.update.IUpdateRule;
import org.deeplearning4j.rl4j.agent.learning.update.UpdateRule;
import org.deeplearning4j.rl4j.agent.learning.update.updater.GradientsNeuralNetUpdater;
import org.deeplearning4j.rl4j.agent.learning.update.updater.INeuralNetUpdater;
import org.deeplearning4j.rl4j.agent.learning.update.updater.LabelsNeuralNetUpdater;
import org.deeplearning4j.rl4j.agent.listener.AgentListener;
import org.deeplearning4j.rl4j.builder.*;
import org.deeplearning4j.rl4j.environment.Environment;
import org.deeplearning4j.rl4j.environment.StepResult;
import org.deeplearning4j.rl4j.experience.ExperienceHandler;
import org.deeplearning4j.rl4j.experience.ReplayMemoryExperienceHandler;
import org.deeplearning4j.rl4j.experience.StateActionExperienceHandler;
import org.deeplearning4j.rl4j.experience.StateActionPair;
import org.deeplearning4j.rl4j.learning.sync.Transition;
import org.deeplearning4j.rl4j.mdp.CartpoleEnvironment;
import org.deeplearning4j.rl4j.network.ITrainableNeuralNet;
import org.deeplearning4j.rl4j.network.configuration.DQNDenseNetworkConfiguration;
import org.deeplearning4j.rl4j.network.dqn.DQNFactory;
import org.deeplearning4j.rl4j.network.dqn.DQNFactoryStdDense;
import org.deeplearning4j.rl4j.network.dqn.IDQN;
import org.deeplearning4j.rl4j.observation.Observation;
import org.deeplearning4j.rl4j.observation.transform.TransformProcess;
import org.deeplearning4j.rl4j.policy.DQNPolicy;
import org.deeplearning4j.rl4j.policy.EpsGreedy;
import org.deeplearning4j.rl4j.policy.INeuralNetPolicy;
import org.deeplearning4j.rl4j.policy.IPolicy;
import org.deeplearning4j.rl4j.trainer.SyncTrainer;
import org.nd4j.linalg.api.ndarray.INDArray;
import org.nd4j.linalg.api.rng.Random;
import org.nd4j.linalg.factory.Nd4j;
import org.nd4j.linalg.learning.config.Adam;

import java.util.ArrayList;
import java.util.List;
import java.util.function.Predicate;

public class AgentLearnerCartpole {

    public static DQNFactoryStdDense.Configuration CARTPOLE_NET =
            DQNFactoryStdDense.Configuration.builder()
                    .l2(0.001).updater(new Adam(0.0005)).numHiddenNodes(16).numLayer(3).build();

    public static void main(String[] args) {
        // Build the network
        DQNDenseNetworkConfiguration netConf = DQNDenseNetworkConfiguration.builder()
                .numLayers(3)
                .numHiddenNodes(16)
                .l2(0.001)
                .updater(new Adam(0.0005))
                .build();
        DQNFactory factory = new DQNFactoryStdDense(netConf);
        IDQN network = factory.buildDQN(new int[] { 4 }, 2);

        Builder<Environment<Integer>> environmentBuilder = CartpoleEnvironment::new;
        Builder<TransformProcess> transformProcessBuilder = () -> TransformProcess.builder()
                .transform("data", new ArrayToINDArrayTransform())
                .build("data");

        Random rnd = Nd4j.getRandomFactory().getNewRandomInstance(123);

        List<AgentListener<Integer>> listeners = new ArrayList<>() {
            {
                add(new EpisodeScorePrinter());
            }
        };

        DoubleDQNBuilder.Configuration configuration = DoubleDQNBuilder.Configuration.builder()
            .policyConfiguration(EpsGreedy.Configuration.builder()
                    .epsilonNbStep(3000)
                    .minEpsilon(0.1)
                    .build())
            .experienceHandlerConfiguration(ReplayMemoryExperienceHandler.Configuration.builder()
                    .maxReplayMemorySize(10000)
                    .batchSize(64)
                    .build())
            .neuralNetUpdaterConfiguration(LabelsNeuralNetUpdater.Configuration.builder()
                    .targetUpdateFrequency(50)
                    .build())
            .updateAlgorithmConfiguration(BaseTransitionTDAlgorithm.Configuration.builder()
                    .gamma(0.99)
                    .build())
            .agentLearnerConfiguration(AgentLearner.Configuration.builder()
                    .maxEpisodeSteps(200)
                    .build())
            .agentLearnerListeners(listeners)
            .build();
        Builder<IAgentLearner<Integer>> builder = new DoubleDQNBuilder(configuration, network, environmentBuilder, transformProcessBuilder, rnd);

        /*
        NStepQLearningBuilder.Configuration configuration = NStepQLearningBuilder.Configuration.builder()
            .policyConfiguration(EpsGreedy.Configuration.builder()
                    .epsilonNbStep(75000)
                    .minEpsilon(0.1)
                    .build())
            .neuralNetUpdaterConfiguration(GradientsNeuralNetUpdater.Configuration.builder()
                    .targetUpdateFrequency(50)
                    .build())
            .nstepQLearningConfiguration(NStepQLearning.Configuration.builder()
                    .build())
            .experienceHandlerConfiguration(StateActionExperienceHandler.Configuration.builder()
                    .batchSize(5)
                    .build())
            .agentLearnerConfiguration(AgentLearner.Configuration.builder()
                    .maxEpisodeSteps(200)
                    .build())
            .agentLearnerListeners(listeners)
            .build();
        Builder<IAgentLearner<Integer>> builder = new NStepQLearningBuilder(configuration, network, environmentBuilder, transformProcessBuilder, rnd);
        */

        // Stop when the max score (200.0) has been hit 5 times in a row or at 5000 episodes, whichever comes first
        Predicate<SyncTrainer<Integer>> stoppingCondition = new StopWhenConsecutiveScore(5, 200.0)
                .or(t -> t.getEpisodeCount() >= 5000);

        SyncTrainer<Integer> trainer = SyncTrainer.<Integer>builder()
                .agentLearnerBuilder(builder)
                .stoppingCondition(stoppingCondition)
                .build();

        trainer.train();
    }

    public static class ArrayToINDArrayTransform implements Operation<double[], INDArray> {
        @Override
        public INDArray transform(double[] data) {
            return Nd4j.create(data);
        }
    }

    public static class StopWhenConsecutiveScore implements Predicate<SyncTrainer<Integer>> {

        private final int numRequiredConsecutiveScore;
        private final double score;
        private int currentConsecutiveScoreCount = 0;

        public StopWhenConsecutiveScore(int numRequiredConsecutiveScore, double score) {
            this.numRequiredConsecutiveScore = numRequiredConsecutiveScore;
            this.score = score;
        }

        @Override
        public boolean test(SyncTrainer<Integer> syncTrainer) {
            if(syncTrainer.getAgentLearner().getReward() >= score) {
                ++currentConsecutiveScoreCount;
            } else {
                currentConsecutiveScoreCount = 0;
            }

            return currentConsecutiveScoreCount >= numRequiredConsecutiveScore;
        }
    }

    private static class EpisodeScorePrinter implements AgentListener<Integer> {
        private int episodeCount;
        @Override
        public ListenerResponse onBeforeEpisode(Agent agent) {
            return ListenerResponse.CONTINUE;
        }

        @Override
        public ListenerResponse onBeforeStep(Agent agent, Observation observation, Integer integer) {
            return ListenerResponse.CONTINUE;
        }

        @Override
        public ListenerResponse onAfterStep(Agent agent, StepResult stepResult) {
            return ListenerResponse.CONTINUE;
        }

        @Override
        public void onAfterEpisode(Agent agent) {
            System.out.println(String.format("Episode %d : score = %.0f", episodeCount, agent.getReward()));
            ++episodeCount;
        }
    }
}
```
## How was this patch tested?

Unit tests and manual tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.
